### PR TITLE
Fix no default property name for token substraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This is a plugin for [insomnia](https://insomnia.rest) that will store a jwt token after successful login to an api, and automatically send it to all further requests that should be authenticated.
 
 ## Usage
-If your api's login route contains `login` in the path, and the response from a successful login inclues the jwt token in the root of the response json, as the property `token` all you need to do is install the plugin inside insomnia, the plugin will do the rest.
+If your api's login route contains `login` in the path, and the response from a successful login includes the jwt token in the root of the response json, as the property `token` all you need to do is install the plugin inside insomnia, the plugin will do the rest.
 
 Once installed (and optionally further configured) upon successful login, the jwt token will be stored within insomnia and automatically populated into future requests.
 

--- a/main.js
+++ b/main.js
@@ -22,7 +22,10 @@ module.exports.requestHooks = [
 module.exports.responseHooks = [
   async context => {
     // get the token field name response from api
-    const tokenName = context.request.getEnvironmentVariable('access_token');
+    let tokenName = context.request.getEnvironmentVariable('access_token');
+    if (!tokenName) {
+      tokenName = 'token';
+    }
     
 
     // check if current route is login
@@ -37,7 +40,7 @@ module.exports.responseHooks = [
     if (isLoginPath) {
       const res = context.response.getBody().toString();
       const data = JSON.parse(res);
-      const token = _get(data, tokenName, 'token');
+      const token = _get(data, tokenName, 'no token');
 
       console.log(tokenName);
       console.log(token);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnia-plugin-jwt-auth",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "insomnia": {
     "name": "jwt-auth-token",
     "description": "This plugin will auto set the bearer authorization header with a jwt token, after its received from a login api response",


### PR DESCRIPTION
As specified in the README.md file:

"_If your api's login route contains `login` in the path, and the response from a successful login inclues the jwt token in the root of the response json, as the property `token` all you need to do is install the plugin inside insomnia, the plugin will do the rest._"

This was not working as intended, the plugin was always looking for the environment variable `access_token` to retrieve the "custom property name" of the token from the json login response.

Changes included in the pull request fix this issue :)